### PR TITLE
Run sbt sbtVersion to download of sbt during the docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN yum clean all && \
 RUN curl https://bintray.com/sbt/rpm/rpm | tee /etc/yum.repos.d/bintray-sbt-rpm.repo && \
     yum install sbt -y
 
+RUN sbt sbtVersion
+
 RUN mkdir -p /root/.sbt/0.13/plugins/ /root/.sbt/1.0/plugins/
 COPY credentials.sbt /root/.sbt/0.13/plugins/
 COPY credentials.sbt /root/.sbt/1.0/plugins/


### PR DESCRIPTION
The current docker image download sbt every time it's used to build a scala project.

This branch downloads sbt during the build so it's already available when the image is used to build a scala project.

Cuts build times by up to 2 minutes